### PR TITLE
Jc/mask top blending

### DIFF
--- a/src/blending/algorithms.rs
+++ b/src/blending/algorithms.rs
@@ -265,3 +265,29 @@ pub fn blend_disjoint_debug((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) 
     bot_pixel[2] = b;
     bot_pixel[3] = a as u8;
 }
+
+#[inline]
+pub fn blend_mask_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+    let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
+    let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
+
+    let factor = 1.0;
+
+    let atf = factor * (at as f32 / 255.0);
+    let abf = 1.0 - atf;
+
+    let mut r = rb as f32 * abf + rt as f32 * atf;
+    let mut g = gb as f32 * abf + gt as f32 * atf;
+    let mut b = bb as f32 * abf + bt as f32 * atf;
+    let mut a = ab as f32 * abf + at as f32 * atf;
+
+    r = max(0.0, min(255.0, r));
+    g = max(0.0, min(255.0, g));
+    b = max(0.0, min(255.0, b));
+    a = max(0.0, min(255.0, a));
+
+    bot_pixel[0] = r as u8;
+    bot_pixel[1] = g as u8;
+    bot_pixel[2] = b as u8;
+    bot_pixel[3] = a as u8;
+}

--- a/src/blending/mod.rs
+++ b/src/blending/mod.rs
@@ -2,8 +2,8 @@ mod algorithms;
 
 use algorithms::{
     blend_alpha, blend_destination_over, blend_disjoint_debug, blend_disjoint_over,
-    blend_disjoint_under, blend_first_bottom, blend_first_top, blend_multiplicative,
-    blend_source_over,
+    blend_disjoint_under, blend_first_bottom, blend_first_top, blend_mask_top,
+    blend_multiplicative, blend_source_over,
 };
 use image::{ImageBuffer, Rgba};
 use std::fmt;
@@ -21,6 +21,7 @@ pub enum BlendAlgorithm {
     DisjointOver,
     DisjointUnder,
     DisjointDebug,
+    MaskTop,
 }
 
 impl FromStr for BlendAlgorithm {
@@ -37,6 +38,7 @@ impl FromStr for BlendAlgorithm {
             "disjoint_over" => Ok(BlendAlgorithm::DisjointOver),
             "disjoint_under" => Ok(BlendAlgorithm::DisjointUnder),
             "disjoint_debug" => Ok(BlendAlgorithm::DisjointDebug),
+            "mask_top" => Ok(BlendAlgorithm::MaskTop),
             s => Err(s.to_string()),
         }
     }
@@ -54,6 +56,7 @@ impl Display for BlendAlgorithm {
             BlendAlgorithm::DisjointOver => write!(f, "disjoint_over"),
             BlendAlgorithm::DisjointUnder => write!(f, "disjoint_under"),
             BlendAlgorithm::DisjointDebug => write!(f, "disjoint_debug"),
+            BlendAlgorithm::MaskTop => write!(f, "mask_top"),
         }
     }
 }
@@ -137,6 +140,7 @@ pub fn get_blending_algorithm(
         BlendAlgorithm::DisjointOver => blend_disjoint_over,
         BlendAlgorithm::DisjointUnder => blend_disjoint_under,
         BlendAlgorithm::DisjointDebug => blend_disjoint_debug,
+        BlendAlgorithm::MaskTop => blend_mask_top,
     }
 }
 
@@ -151,5 +155,6 @@ pub fn is_algorithm_multiplied(algorithm: &BlendAlgorithm) -> bool {
         BlendAlgorithm::DisjointOver => true,
         BlendAlgorithm::DisjointUnder => true,
         BlendAlgorithm::DisjointDebug => true,
+        BlendAlgorithm::MaskTop => false,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,39 @@ pub fn pcompose(args: &mut env::Args) -> Result<(), PConvertError> {
         &mut benchmark,
     )?;
 
+    compose(
+        &dir,
+        BlendAlgorithm::MaskTop,
+        Background::Alpha,
+        CompressionType::Fast,
+        FilterType::NoFilter,
+        &mut benchmark,
+    )?;
+    compose(
+        &dir,
+        BlendAlgorithm::MaskTop,
+        Background::White,
+        CompressionType::Fast,
+        FilterType::NoFilter,
+        &mut benchmark,
+    )?;
+    compose(
+        &dir,
+        BlendAlgorithm::MaskTop,
+        Background::Blue,
+        CompressionType::Fast,
+        FilterType::NoFilter,
+        &mut benchmark,
+    )?;
+    compose(
+        &dir,
+        BlendAlgorithm::MaskTop,
+        Background::Texture,
+        CompressionType::Fast,
+        FilterType::NoFilter,
+        &mut benchmark,
+    )?;
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,5 +23,5 @@ fn main() -> Result<(), PConvertError> {
 }
 
 fn print_usage() {
-    println!("Usage: pconvert-rust <command> [args...]\nwhere command can be one of the following: compose, convert, benchmark, opencl, version");
+    println!("Usage: pconvert-rust <command> [args...]\nwhere command can be one of the following: compose, convert, benchmark, version");
 }

--- a/src/pymodule.rs
+++ b/src/pymodule.rs
@@ -91,19 +91,16 @@ fn pconvert_rust(_py: Python, m: &PyModule) -> PyResult<()> {
             algorithms_to_apply = vec!["multiplicative".to_owned(); num_images - 1]
         }
 
-        let mut zip_iter = img_paths.iter()?.zip(algorithms_to_apply.iter());
-        let first_pair = zip_iter.next().unwrap();
-        let first_path = first_pair.0?.extract::<String>().unwrap();
-
-        let first_algorithm = first_pair.1;
-        let algorithm = get_input_algorithm(first_algorithm)?;
-        let demultiply = is_algorithm_multiplied(&algorithm);
-
-        let mut composition = read_png(first_path, demultiply)?;
+        let mut img_paths_iter = img_paths.iter()?;
+        let first_algorithm = get_input_algorithm(&algorithms_to_apply[0])?;
+        let mut composition = read_png(
+            img_paths_iter.next().unwrap()?.to_string(),
+            is_algorithm_multiplied(&first_algorithm),
+        )?;
+        let mut zip_iter = img_paths_iter.zip(algorithms_to_apply.iter());
         while let Some(pair) = zip_iter.next() {
             let path = pair.0?.extract::<String>()?;
-            let algorithm = pair.1;
-            let algorithm = get_input_algorithm(algorithm)?;
+            let algorithm = get_input_algorithm(pair.1)?;
             let demultiply = is_algorithm_multiplied(&algorithm);
             let algorithm_fn = get_blending_algorithm(&algorithm);
             let current_layer = read_png(path, demultiply)?;


### PR DESCRIPTION
Closes #15 
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/pconvert-rust/issues/12 |
| Dependencies | None |
| Decisions | Implemented mask top blending algorithm in the same way the other algorithms were implemented. For now, the factor is hard-coded as `let factor = 1.0;` but will have to be passed through arguments, to be solved in another issue  |
| Animated GIF | |
