### PR TITLE
Jc/bugfix algorithms sequence parameter

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,6 +65,7 @@ fn main() {
             "multiplicative",
             "source_over",
             "destination_over",
+            "mask_top",
             "first_top",
             "first_bottom",
             "disjoint_over",

--- a/src/blending/algorithms.rs
+++ b/src/blending/algorithms.rs
@@ -1,8 +1,12 @@
+use super::BlendAlgorithmParams;
 use crate::utils::{max, min};
 use image::Rgba;
 
 #[inline]
-pub fn blend_alpha((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_alpha(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -38,7 +42,10 @@ pub fn blend_alpha((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
 }
 
 #[inline]
-pub fn blend_multiplicative((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_multiplicative(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -60,7 +67,10 @@ pub fn blend_multiplicative((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) 
 }
 
 #[inline]
-pub fn blend_source_over((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_source_over(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -96,7 +106,10 @@ pub fn blend_source_over((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
 }
 
 #[inline]
-pub fn blend_destination_over((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_destination_over(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -132,7 +145,10 @@ pub fn blend_destination_over((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)
 }
 
 #[inline]
-pub fn blend_mask_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_mask_top(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -158,7 +174,10 @@ pub fn blend_mask_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
 }
 
 #[inline]
-pub fn blend_first_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_first_top(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -179,7 +198,10 @@ pub fn blend_first_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
 }
 
 #[inline]
-pub fn blend_first_bottom((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_first_bottom(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -200,7 +222,10 @@ pub fn blend_first_bottom((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
 }
 
 #[inline]
-pub fn blend_disjoint_over((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_disjoint_over(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -235,7 +260,10 @@ pub fn blend_disjoint_over((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
 }
 
 #[inline]
-pub fn blend_disjoint_under((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_disjoint_under(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
@@ -270,7 +298,10 @@ pub fn blend_disjoint_under((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) 
 }
 
 #[inline]
-pub fn blend_disjoint_debug((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+pub fn blend_disjoint_debug(
+    (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
+    _params: &Option<BlendAlgorithmParams>,
+) {
     let ab = bot_pixel[3];
     let at = top_pixel[3];
 

--- a/src/blending/algorithms.rs
+++ b/src/blending/algorithms.rs
@@ -1,4 +1,4 @@
-use super::params::BlendAlgorithmParams;
+use super::params::{BlendAlgorithmParams, ParamValue};
 use crate::utils::{max, min};
 use image::Rgba;
 
@@ -147,12 +147,19 @@ pub fn blend_destination_over(
 #[inline]
 pub fn blend_mask_top(
     (bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>),
-    _params: &Option<BlendAlgorithmParams>,
+    params: &Option<BlendAlgorithmParams>,
 ) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
 
-    let factor = 1.0;
+    let factor = params
+        .as_ref()
+        .and_then(|params| params.get("factor"))
+        .and_then(|param| match param {
+            ParamValue::Float(float) => Some(*float),
+            _ => None,
+        })
+        .unwrap_or(1.0) as f32;
 
     let atf = factor * (at as f32 / 255.0);
     let abf = 1.0 - atf;

--- a/src/blending/algorithms.rs
+++ b/src/blending/algorithms.rs
@@ -1,4 +1,4 @@
-use super::BlendAlgorithmParams;
+use super::params::BlendAlgorithmParams;
 use crate::utils::{max, min};
 use image::Rgba;
 

--- a/src/blending/algorithms.rs
+++ b/src/blending/algorithms.rs
@@ -132,6 +132,32 @@ pub fn blend_destination_over((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)
 }
 
 #[inline]
+pub fn blend_mask_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
+    let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
+    let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
+
+    let factor = 1.0;
+
+    let atf = factor * (at as f32 / 255.0);
+    let abf = 1.0 - atf;
+
+    let mut r = rb as f32 * abf + rt as f32 * atf;
+    let mut g = gb as f32 * abf + gt as f32 * atf;
+    let mut b = bb as f32 * abf + bt as f32 * atf;
+    let mut a = ab as f32 * abf + at as f32 * atf;
+
+    r = max(0.0, min(255.0, r));
+    g = max(0.0, min(255.0, g));
+    b = max(0.0, min(255.0, b));
+    a = max(0.0, min(255.0, a));
+
+    bot_pixel[0] = r as u8;
+    bot_pixel[1] = g as u8;
+    bot_pixel[2] = b as u8;
+    bot_pixel[3] = a as u8;
+}
+
+#[inline]
 pub fn blend_first_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
     let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
     let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
@@ -263,31 +289,5 @@ pub fn blend_disjoint_debug((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) 
     bot_pixel[0] = r;
     bot_pixel[1] = g;
     bot_pixel[2] = b;
-    bot_pixel[3] = a as u8;
-}
-
-#[inline]
-pub fn blend_mask_top((bot_pixel, top_pixel): (&mut Rgba<u8>, &Rgba<u8>)) {
-    let (rb, gb, bb, ab) = (bot_pixel[0], bot_pixel[1], bot_pixel[2], bot_pixel[3]);
-    let (rt, gt, bt, at) = (top_pixel[0], top_pixel[1], top_pixel[2], top_pixel[3]);
-
-    let factor = 1.0;
-
-    let atf = factor * (at as f32 / 255.0);
-    let abf = 1.0 - atf;
-
-    let mut r = rb as f32 * abf + rt as f32 * atf;
-    let mut g = gb as f32 * abf + gt as f32 * atf;
-    let mut b = bb as f32 * abf + bt as f32 * atf;
-    let mut a = ab as f32 * abf + at as f32 * atf;
-
-    r = max(0.0, min(255.0, r));
-    g = max(0.0, min(255.0, g));
-    b = max(0.0, min(255.0, b));
-    a = max(0.0, min(255.0, a));
-
-    bot_pixel[0] = r as u8;
-    bot_pixel[1] = g as u8;
-    bot_pixel[2] = b as u8;
     bot_pixel[3] = a as u8;
 }

--- a/src/blending/mod.rs
+++ b/src/blending/mod.rs
@@ -6,11 +6,15 @@ use algorithms::{
     blend_multiplicative, blend_source_over,
 };
 use image::{ImageBuffer, Rgba};
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::result;
 use std::str::FromStr;
 
+pub type BlendAlgorithmParams = HashMap<String, String>;
+
+#[derive(Clone)]
 pub enum BlendAlgorithm {
     Alpha,
     Multiplicative,
@@ -82,10 +86,11 @@ impl Display for Background {
 pub fn blend_images(
     top: &ImageBuffer<Rgba<u8>, Vec<u8>>,
     bot: &mut ImageBuffer<Rgba<u8>, Vec<u8>>,
-    blending_algorithm: &impl Fn((&mut Rgba<u8>, &Rgba<u8>)) -> (),
+    blending_algorithm: &impl Fn((&mut Rgba<u8>, &Rgba<u8>), &Option<BlendAlgorithmParams>) -> (),
+    params: &Option<BlendAlgorithmParams>,
 ) {
     for pixel_pair in bot.pixels_mut().zip(top.pixels()) {
-        blending_algorithm(pixel_pair);
+        blending_algorithm(pixel_pair, params);
     }
 }
 
@@ -129,7 +134,7 @@ fn multiply_pixel(pixel: &mut Rgba<u8>) {
 
 pub fn get_blending_algorithm(
     algorithm: &BlendAlgorithm,
-) -> impl Fn((&mut Rgba<u8>, &Rgba<u8>)) -> () {
+) -> impl Fn((&mut Rgba<u8>, &Rgba<u8>), &Option<BlendAlgorithmParams>) -> () {
     match algorithm {
         BlendAlgorithm::Alpha => blend_alpha,
         BlendAlgorithm::Multiplicative => blend_multiplicative,

--- a/src/blending/mod.rs
+++ b/src/blending/mod.rs
@@ -1,4 +1,5 @@
 mod algorithms;
+pub mod params;
 
 use algorithms::{
     blend_alpha, blend_destination_over, blend_disjoint_debug, blend_disjoint_over,
@@ -6,13 +7,11 @@ use algorithms::{
     blend_multiplicative, blend_source_over,
 };
 use image::{ImageBuffer, Rgba};
-use std::collections::HashMap;
+use params::BlendAlgorithmParams;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::result;
 use std::str::FromStr;
-
-pub type BlendAlgorithmParams = HashMap<String, String>;
 
 #[derive(Clone)]
 pub enum BlendAlgorithm {

--- a/src/blending/mod.rs
+++ b/src/blending/mod.rs
@@ -16,12 +16,12 @@ pub enum BlendAlgorithm {
     Multiplicative,
     SourceOver,
     DestinationOver,
+    MaskTop,
     FirstTop,
     FirstBottom,
     DisjointOver,
     DisjointUnder,
     DisjointDebug,
-    MaskTop,
 }
 
 impl FromStr for BlendAlgorithm {
@@ -33,12 +33,12 @@ impl FromStr for BlendAlgorithm {
             "multiplicative" => Ok(BlendAlgorithm::Multiplicative),
             "source_over" => Ok(BlendAlgorithm::SourceOver),
             "destination_over" => Ok(BlendAlgorithm::DestinationOver),
+            "mask_top" => Ok(BlendAlgorithm::MaskTop),
             "first_top" => Ok(BlendAlgorithm::FirstTop),
             "first_bottom" => Ok(BlendAlgorithm::FirstBottom),
             "disjoint_over" => Ok(BlendAlgorithm::DisjointOver),
             "disjoint_under" => Ok(BlendAlgorithm::DisjointUnder),
             "disjoint_debug" => Ok(BlendAlgorithm::DisjointDebug),
-            "mask_top" => Ok(BlendAlgorithm::MaskTop),
             s => Err(s.to_string()),
         }
     }
@@ -51,12 +51,12 @@ impl Display for BlendAlgorithm {
             BlendAlgorithm::Multiplicative => write!(f, "multiplicative"),
             BlendAlgorithm::SourceOver => write!(f, "source_over"),
             BlendAlgorithm::DestinationOver => write!(f, "destination_over"),
+            BlendAlgorithm::MaskTop => write!(f, "mask_top"),
             BlendAlgorithm::FirstTop => write!(f, "first_top"),
             BlendAlgorithm::FirstBottom => write!(f, "first_bottom"),
             BlendAlgorithm::DisjointOver => write!(f, "disjoint_over"),
             BlendAlgorithm::DisjointUnder => write!(f, "disjoint_under"),
             BlendAlgorithm::DisjointDebug => write!(f, "disjoint_debug"),
-            BlendAlgorithm::MaskTop => write!(f, "mask_top"),
         }
     }
 }
@@ -135,12 +135,12 @@ pub fn get_blending_algorithm(
         BlendAlgorithm::Multiplicative => blend_multiplicative,
         BlendAlgorithm::SourceOver => blend_source_over,
         BlendAlgorithm::DestinationOver => blend_destination_over,
+        BlendAlgorithm::MaskTop => blend_mask_top,
         BlendAlgorithm::FirstTop => blend_first_top,
         BlendAlgorithm::FirstBottom => blend_first_bottom,
         BlendAlgorithm::DisjointOver => blend_disjoint_over,
         BlendAlgorithm::DisjointUnder => blend_disjoint_under,
         BlendAlgorithm::DisjointDebug => blend_disjoint_debug,
-        BlendAlgorithm::MaskTop => blend_mask_top,
     }
 }
 
@@ -150,11 +150,11 @@ pub fn is_algorithm_multiplied(algorithm: &BlendAlgorithm) -> bool {
         BlendAlgorithm::Multiplicative => false,
         BlendAlgorithm::SourceOver => false,
         BlendAlgorithm::DestinationOver => false,
+        BlendAlgorithm::MaskTop => false,
         BlendAlgorithm::FirstTop => false,
         BlendAlgorithm::FirstBottom => false,
         BlendAlgorithm::DisjointOver => true,
         BlendAlgorithm::DisjointUnder => true,
         BlendAlgorithm::DisjointDebug => true,
-        BlendAlgorithm::MaskTop => false,
     }
 }

--- a/src/blending/params.rs
+++ b/src/blending/params.rs
@@ -1,0 +1,12 @@
+use std::collections::HashMap;
+
+pub type BlendAlgorithmParams = HashMap<String, ParamValue>;
+
+#[derive(Clone)]
+pub enum ParamValue {
+    Bool(bool),
+    Int(i32),
+    Long(i64),
+    Float(f64),
+    Str(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,7 +509,7 @@ fn compose(
     })?;
 
     benchmark.execute(Benchmark::add_blend_time, || {
-        blend_images(&top, &mut bot, &algorithm_fn)
+        blend_images(&top, &mut bot, &algorithm_fn, &None)
     });
 
     let top = benchmark.execute(Benchmark::add_read_png_time, || {
@@ -517,7 +517,7 @@ fn compose(
     })?;
 
     benchmark.execute(Benchmark::add_blend_time, || {
-        blend_images(&top, &mut bot, &algorithm_fn)
+        blend_images(&top, &mut bot, &algorithm_fn, &None)
     });
 
     let top = benchmark.execute(Benchmark::add_read_png_time, || {
@@ -525,7 +525,7 @@ fn compose(
     })?;
 
     benchmark.execute(Benchmark::add_blend_time, || {
-        blend_images(&top, &mut bot, &algorithm_fn)
+        blend_images(&top, &mut bot, &algorithm_fn, &None)
     });
 
     if demultiply {
@@ -537,7 +537,7 @@ fn compose(
     })?;
 
     benchmark.execute(Benchmark::add_blend_time, || {
-        blend_images(&bot, &mut composition, &algorithm_fn)
+        blend_images(&bot, &mut composition, &algorithm_fn, &None)
     });
 
     let file_out = format!(

--- a/src/pymodule.rs
+++ b/src/pymodule.rs
@@ -133,18 +133,21 @@ fn validate_algorithm(algorithm: &String) -> Result<BlendAlgorithm, PyErr> {
 
 fn validate_algorithms(
     algorithms: &PySequence,
-) -> Result<Vec<(BlendAlgorithm, BlendAlgorithmParams)>, PyErr> {
-    let result = Vec::new();
+) -> Result<Vec<(BlendAlgorithm, Option<BlendAlgorithmParams>)>, PyErr> {
+    let mut result = Vec::new();
 
     for i in 0..algorithms.len()? {
 
         let element = algorithms.get_item(i)?;
 
         if let Ok(string) = element.cast_as::<PyString>() {
-            println!("Got string {}", string);
-            validate_algorithm(string.to_string());
+            println!("Got string {}", string); //TODO: remove
+            let algorithm = validate_algorithm(&string.to_string()?.into_owned())?;
+            result.push((algorithm, None));
         } else if let Ok(tuple) = element.cast_as::<PyTuple>() {
-            println!("Got tuple {}", tuple);
+            println!("Got tuple {}", tuple); //TODO: remove
+            let algorithm = validate_algorithm(&tuple.get_item(0).to_string())?;
+            //TODO get the other variables
         }
     }
 

--- a/src/pymodule.rs
+++ b/src/pymodule.rs
@@ -95,10 +95,10 @@ fn pconvert_rust(_py: Python, m: &PyModule) -> PyResult<()> {
 
         let mut img_paths_iter = img_paths.iter()?;
         let first_algorithm = validate_algorithm(&algorithms_to_apply[0])?;
-        let mut composition = read_png(
-            img_paths_iter.next().unwrap()?.to_string(),
-            is_algorithm_multiplied(&first_algorithm),
-        )?;
+
+        let first_path = img_paths_iter.next().unwrap()?.to_string();
+        let first_demultiply = is_algorithm_multiplied(&first_algorithm);
+        let mut composition = read_png(first_path, first_demultiply)?;
         let mut zip_iter = img_paths_iter.zip(algorithms_to_apply.iter());
         while let Some(pair) = zip_iter.next() {
             let path = pair.0?.extract::<String>()?;

--- a/src/pymodule.rs
+++ b/src/pymodule.rs
@@ -37,7 +37,7 @@ fn pconvert_rust(_py: Python, m: &PyModule) -> PyResult<()> {
         is_inline: Option<bool>,
     ) -> PyResult<()> {
         let algorithm = algorithm.unwrap_or(String::from("multiplicative"));
-        let algorithm = parse_algorithm(&algorithm)?;
+        let algorithm = build_algorithm(&algorithm)?;
 
         let _is_inline = is_inline.unwrap_or(false);
 
@@ -87,7 +87,7 @@ fn pconvert_rust(_py: Python, m: &PyModule) -> PyResult<()> {
             if let Some(algorithms) = algorithms {
                 build_params(algorithms)?
             } else if let Some(algorithm) = algorithm {
-                let algorithm = parse_algorithm(&algorithm)?;
+                let algorithm = build_algorithm(&algorithm)?;
                 vec![(algorithm, None); num_images - 1]
             } else {
                 vec![(BlendAlgorithm::Multiplicative, None); num_images - 1]
@@ -120,7 +120,7 @@ fn pconvert_rust(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-fn parse_algorithm(algorithm: &String) -> Result<BlendAlgorithm, PyErr> {
+fn build_algorithm(algorithm: &String) -> Result<BlendAlgorithm, PyErr> {
     match BlendAlgorithm::from_str(algorithm) {
         Ok(algorithm) => Ok(algorithm),
         Err(algorithm) => Err(PyErr::from(PConvertError::ArgumentError(format!(
@@ -139,11 +139,11 @@ fn build_params(
         let element = algorithms.get_item(i)?;
 
         if let Ok(string) = element.cast_as::<PyString>() {
-            let algorithm = parse_algorithm(&string.to_string()?.into_owned())?;
+            let algorithm = build_algorithm(&string.to_string()?.into_owned())?;
             result.push((algorithm, None));
         } else if let Ok(sequence) = element.cast_as::<PySequence>() {
             let algorithm = sequence.get_item(0)?.extract::<String>()?;
-            let algorithm = parse_algorithm(&algorithm)?;
+            let algorithm = build_algorithm(&algorithm)?;
 
             let mut blending_params = BlendAlgorithmParams::new();
             let params_sequence = sequence.get_item(1)?;

--- a/src/pymodule.rs
+++ b/src/pymodule.rs
@@ -148,6 +148,13 @@ fn validate_algorithms(
             println!("Got tuple {}", tuple); //TODO: remove
             let algorithm = validate_algorithm(&tuple.get_item(0).to_string())?;
             //TODO get the other variables
+            let mut params = BlendAlgorithmParams::new();
+            for pair in tuple.iter() {
+                let key_value = pair.cast_as::<PyTuple>()?;
+                params.insert(key_value.get_item(0).to_string(), key_value.get_item(1).to_string());
+            }
+            let algorithm_config = (algorithm, Some(params));
+            result.push(algorithm_config);
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use super::blending::demultiply_image;
 use super::errors::PConvertError;
+use image::io::Reader;
 use image::png::{CompressionType, FilterType, PngEncoder};
-use image::ColorType;
-use image::{open, DynamicImage, ImageBuffer, Rgba};
+use image::{ColorType, DynamicImage, ImageBuffer, ImageFormat, Rgba};
 use std::fs::File;
 use std::io::BufWriter;
 
@@ -10,12 +10,12 @@ pub fn read_png(
     file_in: String,
     demultiply: bool,
 ) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, PConvertError> {
-    let mut img = match open(&file_in) {
-        Ok(file) => match file {
-            DynamicImage::ImageRgba8(img) => img,
-            _ => return Err(PConvertError::UnsupportedImageTypeError),
-        },
-        Err(err) => return Err(PConvertError::ImageLibError(err)),
+    let reader = Reader::open(file_in)?;
+    let reader = Reader::with_format(reader.into_inner(), ImageFormat::Png);
+
+    let mut img = match reader.decode() {
+        Ok(DynamicImage::ImageRgba8(img)) => img,
+        _ => return Err(PConvertError::UnsupportedImageTypeError),
     };
 
     if demultiply {


### PR DESCRIPTION
Fix #13 
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/pconvert-rust/issues/13 |
| Dependencies | None |
| Decisions | 1. C unions are not memory safe. Rust provides enums that can hold data. Therefore, the common Rust practice to implement a **safe** union is to use a enum with the possible fields, each holding its different data type. In this PR that enum is named [ParamValue](https://github.com/ripe-tech/pconvert-rust/blob/jc/bugfix-algorithms-sequence-parameter/src/blending/params.rs#L6). <br/> 2. Each blending function receives an `params: Option` argument: if it contains something, it will be the extra parameters; if not, the function uses the defaults. <br/> 3. The parsing of these parameters is done by going through the sequence of provided parameters and storing in an hashmap the name of the parameter (string) and the value of type `ParamValue`  |
| Screenshot | ![Screenshot from 2020-09-15 12-16-15](https://user-images.githubusercontent.com/16060539/93204039-50e5c780-f74d-11ea-8e3c-3f5a2547153c.png)  |

