### PR TITLE
Jc/mtpng png encoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 image = "0.23.9"
+mtpng = "0.3.4"
 
 [dependencies.pyo3]
 version = "0.11.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use parallelism::{ResultMessage, ThreadPool};
 use std::env;
 use std::str;
 use std::str::FromStr;
-use utils::{read_png, write_png};
+use utils::{read_png, write_png, write_png_parallel};
 
 pub fn pcompose(args: &mut env::Args) -> Result<(), PConvertError> {
     let dir = match args.next() {
@@ -658,7 +658,7 @@ fn compose_parallel(
         dir, algorithm, background, compression, filter
     );
     benchmark.execute(Benchmark::add_write_png_time, || {
-        write_png(file_out, &composition, compression, filter)
+        write_png_parallel(file_out, &composition, compression, filter)
     })?;
 
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use super::errors::PConvertError;
 use image::io::Reader;
 use image::png::{CompressionType, FilterType, PngEncoder};
 use image::{ColorType, DynamicImage, ImageBuffer, ImageFormat, Rgba};
+use mtpng;
 use std::fs::File;
 use std::io::BufWriter;
 
@@ -35,6 +36,31 @@ pub fn write_png(
     let buff = BufWriter::new(file);
     let encoder = PngEncoder::new_with_quality(buff, compression, filter);
     Ok(encoder.encode(&png, png.width(), png.height(), ColorType::Rgba8)?)
+}
+
+pub fn write_png_parallel(
+    file_out: String,
+    png: &ImageBuffer<Rgba<u8>, Vec<u8>>,
+    _compression: CompressionType,
+    _filter: FilterType,
+) -> Result<(), PConvertError> {
+    let writer = File::create(file_out)?;
+
+    let mut header = mtpng::Header::new();
+    header.set_size(png.width(), png.height())?;
+    header.set_color(mtpng::ColorType::TruecolorAlpha, 8)?;
+
+    let options = mtpng::encoder::Options::new();
+    // options.set_compression_level(level: CompressionLevel)
+    // options.set_filter_mode(filter_mode: Mode<Filter>)
+
+    let mut encoder = mtpng::encoder::Encoder::new(writer, &options);
+
+    encoder.write_header(&header)?;
+    encoder.write_image_rows(&png)?;
+    encoder.finish()?;
+
+    Ok(())
 }
 
 pub fn max<T: PartialOrd>(x: T, y: T) -> T {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Parallel PNG write |
| Dependencies | `mtpng` crate |
| Decisions | Makes use of the `mtpng` crate to write the final compositions PNGs. The integration with current data structures used from the `image` crate is quite simple (see [this](https://github.com/ripe-tech/pconvert-rust/blob/jc/mtpng-png-encoder/src/utils.rs#L41)). Required a mapping of compression and filter types from the `image` crate to the `mtpng` crate (not 100% compatible, some types exist in one but not in the other) |
| Screenshot | ![Screenshot from 2020-09-23 11-59-59](https://user-images.githubusercontent.com/16060539/94004261-56b65b00-fd94-11ea-9eb3-aeed094df618.png) |
