### PR TITLE
Find available features at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To run the demo, follow [this](https://developer.mozilla.org/en-US/docs/WebAssem
 
 ## Usage
 
-Check the [demo site](demo/wasm/index.js) to see how to use the PConvert WASM module.
+Check the [demo site](examples/wasm/index.js) to see how to use the PConvert WASM module.
 
 JavaScript API exposed:
 ```javascript
@@ -116,7 +116,7 @@ pip install pconvert-rust/.
 
 ## Usage
 
-Check [this folder](demo/python/) for examples.
+Check [this folder](examples/python/) for examples.
 
 Import the python package with:
 

--- a/build.rs
+++ b/build.rs
@@ -105,7 +105,17 @@ fn main() {
     );
     write_str_constant_to_file(&mut file, "LIBPNG_VERSION", &libpng_version);
 
-    write_vec_constant_to_file(&mut file, "FEATURES", vec!["cpu", "python"]);
+    let mut features = vec!["cpu"];
+
+    if cfg!(feature = "wasm-extension") {
+        features.push("wasm")
+    }
+
+    if cfg!(feature = "python-extension") {
+        features.push("python")
+    }
+
+    write_vec_constant_to_file(&mut file, "FEATURES", features);
 
     write_str_constant_to_file(
         &mut file,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | PConvert Rust `FEATURES` |
| Dependencies | None |
| Decisions | Find out at compile time which features are active (assuming `cpu` is always set (while in original pconvert it could be either `cpu` or `opencl`) |
