### PR TITLE
Patch the image crate breaking change introduced in last release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: cargo build
+      - run: cargo build --features python-extension
+      - run: cargo build --features wasm-extension
       - run: cargo run version
       - run: cargo run benchmark assets/demo/
+      - run: cargo run benchmark assets/demo/ --parallel
+      - run: cargo doc --lib --all-features

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@
 /// );
 /// ```
 use chrono::Utc;
-use image::png::{CompressionType, FilterType};
+use image::codecs::png::{CompressionType, FilterType};
 use num_cpus;
 use regex::Regex;
 use std::fs::{File, OpenOptions};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use image::png::{CompressionType, FilterType};
+use image::codecs::png::{CompressionType, FilterType};
 use image::{ImageFormat, Rgba};
 use pconvert_rust::benchmark::Benchmark;
 use pconvert_rust::blending::{

--- a/src/pymodule/README.md
+++ b/src/pymodule/README.md
@@ -41,8 +41,8 @@ The parameter `options` is a python dictionary of optional parameters. It may lo
 }
 ```
 
-If `num_threads` is specified with a value of 1 or more, the work load is distributed across multiple threads (belonging to the internally managed thread pool). 
+If `num_threads` is specified with a value of 1 or more, the work load is distributed across multiple threads (belonging to the internally managed thread pool).
 
-For example, for `num_threads: 5`, pconvert ensures there exist at least 5 threads in the pool. However, these may be occupied. Hence, this property is a request of a certain degree of parallelism, but it is not certain that the number of threads is the same. 
+For example, for `num_threads: 5`, pconvert ensures there exist at least 5 threads in the pool. However, these may be occupied. Hence, this property is a request of a certain degree of parallelism, but it is not certain that the number of threads is the same.
 
 Additionally, the pool has a maximum number of threads.

--- a/src/pymodule/utils.rs
+++ b/src/pymodule/utils.rs
@@ -65,7 +65,7 @@ pub fn build_params(
     Ok(result)
 }
 
-/// Retrieves the `image::png::CompressionType` value from the `Options` map if it exists.
+/// Retrieves the `image::codecs::png::CompressionType` value from the `Options` map if it exists.
 /// Otherwise it returns the default value: `CompressionType::Fast`.
 pub fn get_compression_type(options: &Option<Options>) -> CompressionType {
     options.clone().map_or(CompressionType::Fast, |options| {
@@ -78,7 +78,7 @@ pub fn get_compression_type(options: &Option<Options>) -> CompressionType {
     })
 }
 
-/// Retrieves the `image::png::FilterType` value from the `Options` map if it exists.
+/// Retrieves the `image::codecs::png::FilterType` value from the `Options` map if it exists.
 /// Otherwise it returns the default value: `FilterType::NoFilter`.
 pub fn get_filter_type(options: &Option<Options>) -> FilterType {
     options.clone().map_or(FilterType::NoFilter, |options| {

--- a/src/pymodule/utils.rs
+++ b/src/pymodule/utils.rs
@@ -4,7 +4,7 @@ use crate::blending::params::{BlendAlgorithmParams, Options, Value};
 use crate::blending::BlendAlgorithm;
 use crate::errors::PConvertError;
 use crate::utils::{image_compression_from, image_filter_from};
-use image::png::{CompressionType, FilterType};
+use image::codecs::png::{CompressionType, FilterType};
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyString};
 use std::str::FromStr;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,13 +4,13 @@
 
 use crate::blending::demultiply_image;
 use crate::errors::PConvertError;
-use image::png::{CompressionType, FilterType, PngDecoder, PngEncoder};
+use image::codecs::png::{CompressionType, FilterType, PngDecoder, PngEncoder};
 use image::ImageDecoder;
 use image::{ColorType, ImageBuffer, Rgba};
 use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "wasm-extension"))]
 use mtpng;
 
 /// Decodes and returns a PNG.
@@ -99,7 +99,7 @@ pub fn write_png_to_file(
 /// * `png` - A byte buffer with the image data
 /// * `compression` - Compression type to use in the encoding
 /// * `filter` - Filter type to use in the encoding
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "wasm-extension"))]
 pub fn write_png_parallel(
     file_out: String,
     png: &ImageBuffer<Rgba<u8>, Vec<u8>>,
@@ -122,6 +122,24 @@ pub fn write_png_parallel(
     encoder.finish()?;
 
     Ok(())
+}
+
+/// [SUPPORTED IN WASM] WASM stub; single-threaded write PNG to the local file system.
+///
+/// # Arguments
+///
+/// * `file_out` - Local file system path where to write the PNG file
+/// * `png` - A byte buffer with the image data
+/// * `compression` - Compression type to use in the encoding
+/// * `filter` - Filter type to use in the encoding
+#[cfg(feature = "wasm-extension")]
+pub fn write_png_parallel(
+    file_out: String,
+    png: &ImageBuffer<Rgba<u8>, Vec<u8>>,
+    compression: CompressionType,
+    filter: FilterType,
+) -> Result<(), PConvertError> {
+    write_png_to_file(file_out, png, compression, filter)
 }
 
 /// Converts a `String` to a `image::png::CompressionType`.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -142,7 +142,7 @@ pub fn write_png_parallel(
     write_png_to_file(file_out, png, compression, filter)
 }
 
-/// Converts a `String` to a `image::png::CompressionType`.
+/// Converts a `String` to a `image::codecs::png::CompressionType`.
 /// This can not be done by implementing the trait `From<String> for CompressionType` due to Rust's
 /// [orphan rule](https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type).
 pub fn image_compression_from(compression: String) -> CompressionType {
@@ -156,7 +156,7 @@ pub fn image_compression_from(compression: String) -> CompressionType {
     }
 }
 
-/// Converts a `String` to a `image::png::FilterType`.
+/// Converts a `String` to a `image::codecs::png::FilterType`.
 /// This can not be done by implementing the trait `From<String> for FilterType` due to Rust's
 /// [orphan rule](https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type).
 pub fn image_filter_from(filter: String) -> FilterType {

--- a/src/wasm/benchmark.rs
+++ b/src/wasm/benchmark.rs
@@ -3,7 +3,7 @@
 use crate::constants;
 use crate::wasm::utils::{encode_file, load_png, log_benchmark, log_benchmark_header};
 use crate::wasm::{blend_image_buffers, blend_multiple_buffers};
-use image::png::{CompressionType, FilterType};
+use image::codecs::png::{CompressionType, FilterType};
 use js_sys::try_iter;
 use wasm_bindgen::prelude::*;
 use web_sys::File;

--- a/src/wasm/utils.rs
+++ b/src/wasm/utils.rs
@@ -118,7 +118,7 @@ pub fn build_params(
     Ok(result)
 }
 
-/// Retrieves the `image::png::CompressionType` value from the `HashMap<String, JSONValue>` map if it exists.
+/// Retrieves the `image::codecs::png::CompressionType` value from the `HashMap<String, JSONValue>` map if it exists.
 /// Otherwise it returns the default value: `CompressionType::Fast`.
 pub fn get_compression_type(options: &Option<HashMap<String, JSONValue>>) -> CompressionType {
     options.as_ref().map_or(CompressionType::Fast, |options| {
@@ -131,7 +131,7 @@ pub fn get_compression_type(options: &Option<HashMap<String, JSONValue>>) -> Com
     })
 }
 
-/// Retrieves the `image::png::FilterType` value from the `HashMap<String, JSONValue>` map if it exists.
+/// Retrieves the `image::codecs::png::FilterType` value from the `HashMap<String, JSONValue>` map if it exists.
 /// Otherwise it returns the default value: `FilterType::NoFilter`.
 pub fn get_filter_type(options: &Option<HashMap<String, JSONValue>>) -> FilterType {
     options.as_ref().map_or(FilterType::NoFilter, |options| {

--- a/src/wasm/utils.rs
+++ b/src/wasm/utils.rs
@@ -9,7 +9,7 @@ use crate::errors::PConvertError;
 use crate::utils::{decode_png, encode_png};
 use crate::utils::{image_compression_from, image_filter_from};
 use crate::wasm::conversions::JSONParams;
-use image::png::{CompressionType, FilterType};
+use image::codecs::png::{CompressionType, FilterType};
 use image::{ImageBuffer, Rgba};
 use js_sys::{Array, Uint8Array};
 use serde_json::Value as JSONValue;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | None |
| Dependencies | None |
| Decisions | 1. Change the `image::png::CompressionType` and `image::png::FilterType` imports to `image::codecs::png::CompressionType` and `image::codecs::png::FilterType` |
| Animated GIF | None |
