### PR TITLE
Adds WASM module nodejs entrypoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde_json = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { version = "0.3", features =  ["File", "ImageData"], optional = true }
-nodejs-helper = "0.0.3"
 
 # `--features python-extension` dependencies
 pyo3 = { version = "0.12", features = ["extension-module"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { version = "0.3", features =  ["File", "ImageData"], optional = true }
+nodejs-helper = "0.0.3"
 
 # `--features python-extension` dependencies
 pyo3 = { version = "0.12", features = ["extension-module"], optional = true }

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -216,8 +216,8 @@ pub fn get_module_constants_js() -> JsValue {
 /// [NodeJS only]
 /// Blends multiple images read from local file system into one using `algorithm` or `algorithms` and the extra
 /// `options` given. Algorithm defaults to `BlendAlgorithm::Multiplicative`.
-#[wasm_bindgen(js_name = blendMultipleFromLocalFs)]
-pub fn blend_multiple_from_local_fs(
+#[wasm_bindgen(js_name = blendMultipleFs)]
+pub fn blend_multiple_fs(
     image_paths: Box<[JsValue]>,
     out_path: String,
     algorithm: Option<String>,

--- a/src/wasm/utils.rs
+++ b/src/wasm/utils.rs
@@ -22,9 +22,21 @@ use web_sys::{File, ImageData};
 
 #[wasm_bindgen]
 extern "C" {
+    #[derive(Clone, Debug)]
+    pub type NodeFs;
+
     /// JavaScript `console.log` function
     #[wasm_bindgen(js_namespace = console)]
     pub fn log(s: &str);
+
+    #[wasm_bindgen(js_name = require)]
+    pub fn node_require(s: &str) -> NodeFs;
+
+    #[wasm_bindgen(method, js_name = readFileSync, structural)]
+    fn readFileSync(me: &NodeFs, path: &str) -> Vec<u8>;
+
+    #[wasm_bindgen(method, js_name = writeFileSync, structural)]
+    fn writeFileSync(me: &NodeFs, path: &str, data: &[u8]);
 }
 
 macro_rules! console_log {
@@ -177,4 +189,12 @@ pub fn log_benchmark(
             write_time
         )
     );
+}
+
+pub fn node_read_file_sync(fs: &NodeFs, path: &str) -> Vec<u8> {
+    fs.readFileSync(path)
+}
+
+pub fn node_write_file_sync(fs: &NodeFs, path: &str, data: &[u8]) {
+    fs.writeFileSync(path, data);
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | None |
| Dependencies | `node_js_helper` |
| Decisions | This PR adds a new entrypoint to the WASM module, one that takes string paths to the local file system, meant to be used in a nodeJS environment. NodeJS has no `File` or `ImageData` types so the WASM web entrypoints created do not work. Furthermore, this allows the light composition nodes to work the same way, both python and nodejs versions. |
