### PR TITLE
fix: ci versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension
       - run: PYTHON3="${pythonLocation}/bin/python3" PIP3="${pythonLocation}/bin/python3 -m pip" ./deploy.sh
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,10 +52,9 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension
+      - run: apt update && apt-get install -y -q python3.9 python3-pip
+      - run: cargo run version
+      - run: cargo build --features python-extension
       - run: PYTHON3="${pythonLocation}/bin/python3" PIP3="${pythonLocation}/bin/python3 -m pip" ./deploy.sh
         env:
           PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - run: apt update && apt-get install -y -q python3.9 python3-pip
       - run: cargo run version
       - run: cargo build --features python-extension
-      - run: PYTHON3="${pythonLocation}/bin/python3" PIP3="${pythonLocation}/bin/python3 -m pip" ./deploy.sh
+      - run: PYTHON3=$(which python3) PIP3="$(which python3) -m pip" ./deploy.sh
         env:
           PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy crates.io
     strategy:
       matrix:
-        rust-version: ["1.56.1"]
+        rust-version: ["1.61"]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
@@ -21,7 +21,7 @@ jobs:
     name: Deploy NPM
     strategy:
       matrix:
-        rust-version: ["1.56.1"]
+        rust-version: ["1.61"]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
@@ -47,7 +47,7 @@ jobs:
     name: Deploy PyPI
     strategy:
       matrix:
-        rust-version: ["1.56.1"]
+        rust-version: ["1.61"]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: apt update && apt-get install -y -q python3.9 python3-pip
-      - run: export PYTHON3=$(whereis python3)
-      - run: echo $PYTHON3
       - run: cargo run version
       - run: cargo build --features python-extension
       - run: python3 -m pip install --upgrade .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: apt update && apt-get install python3.9
-      - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension
+      - run: cargo build --features python-extension
       - run: cargo run version
-      - run: ${pythonLocation}/bin/python3 -m pip install --upgrade .
-      - run: ${pythonLocation}/bin/python3 setup.py test
+      - run: python3 -m pip install --upgrade .
+      - run: python3 setup.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - run: apt update && apt-get install python3.9
+      - run: apt update && apt-get install python3.9 python3-pip
       - run: cargo build --features python-extension
       - run: cargo run version
       - run: python3 -m pip3 install --upgrade .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: apt update && apt-get install -y -q python3.9 python3-pip
-      - run: PYTHON3="${whereis python3}" echo $PYTHON3
+      - run: PYTHON3=$(whereis python3) echo $PYTHON3
       - run: cargo run version
       - run: cargo build --features python-extension
       - run: python3 -m pip install --upgrade .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,13 +44,9 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - name: Setup Python 3.8
-        run: |
-          apt update
-          apt-get install -y software-properties-common 
-          add-apt-repository -y ppa:deadsnakes/ppa
-          apt-get install -y python3.8
-          ln -s `which python3.8` /usr/local/bin/python
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
       - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension
       - run: cargo run version
       - run: ${pythonLocation}/bin/python3 -m pip install --upgrade .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,9 @@ jobs:
     name: Build Python
     strategy:
       matrix:
-        rust-version: [latest]
+        rust-version: ["1.61"]
     runs-on: ubuntu-latest
-    container: rust:${{ matrix.rust-version }}
+    container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,5 @@ jobs:
       - run: apt update && apt-get install -y -q python3.9 python3-pip
       - run: cargo build --features python-extension
       - run: cargo run version
-      - run: python3 -m pip3 install --upgrade .
+      - run: python3 -m pip install --upgrade .
       - run: python3 setup.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,7 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
+      - run: apt update && apt-get install python3.9
       - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension
       - run: cargo run version
       - run: ${pythonLocation}/bin/python3 -m pip install --upgrade .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,9 @@ jobs:
     name: Build Python
     strategy:
       matrix:
-        rust-version: ["1.61"]
+        rust-version: [latest]
     runs-on: ubuntu-latest
-    container: rust:${{ matrix.rust-version }}-bullseye
+    container: rust:${{ matrix.rust-version }}
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: apt update && apt-get install -y -q python3.9 python3-pip
-      - run: PYTHON3=$(whereis python3) echo $PYTHON3
+      - run: export PYTHON3=$(whereis python3)
+      - run: echo $PYTHON3
       - run: cargo run version
       - run: cargo build --features python-extension
       - run: python3 -m pip install --upgrade .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: cargo run version
-      - run: cargo build
       - run: cargo test
+      - run: cargo build
       - run: cargo run benchmark assets/demo/
       - run: cargo run benchmark assets/demo/ --parallel
   build-complete:
@@ -43,7 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: apt update && apt-get install -y -q python3.9 python3-pip
-      - run: cargo build --features python-extension
+      - run: PYTHON3="${whereis python3}" echo $PYTHON3
       - run: cargo run version
+      - run: cargo build --features python-extension
       - run: python3 -m pip install --upgrade .
       - run: python3 setup.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build Python
     strategy:
       matrix:
-        rust-version: ["1.61", latest]
+        rust-version: ["1.61"]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,13 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
+      - name: Setup Python 3.8
+        run: |
+          apt update
+          apt-get install -y software-properties-common 
+          add-apt-repository -y ppa:deadsnakes/ppa
+          apt-get install -y python3.8
+          ln -s `which python3.8` /usr/local/bin/python
       - run: PYO3_PYTHON="${pythonLocation}/bin/python3" cargo build --features python-extension
       - run: cargo run version
       - run: ${pythonLocation}/bin/python3 -m pip install --upgrade .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,9 @@ jobs:
     container: rust:${{ matrix.rust-version }}
     steps:
       - uses: actions/checkout@v1
+      - run: cargo run version
       - run: cargo build
       - run: cargo test
-      - run: cargo build
-      - run: cargo run version
       - run: cargo run benchmark assets/demo/
       - run: cargo run benchmark assets/demo/ --parallel
   build-complete:
@@ -28,10 +27,9 @@ jobs:
     container: rust:${{ matrix.rust-version }}
     steps:
       - uses: actions/checkout@v1
-      - run: cargo build
+      - run: cargo run version
       - run: cargo test
       - run: cargo build --features wasm-extension
-      - run: cargo run version
       - run: cargo run benchmark assets/demo/
       - run: cargo run benchmark assets/demo/ --parallel
       - run: cargo doc --lib --all-features
@@ -47,5 +45,5 @@ jobs:
       - run: apt update && apt-get install python3.9
       - run: cargo build --features python-extension
       - run: cargo run version
-      - run: python3 -m pip install --upgrade .
+      - run: python3 -m pip3 install --upgrade .
       - run: python3 setup.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        rust-version: ["1.56.1", "1.57", "1.58", "1.59", "1.60", "1.61", "1.62", "1.63", latest]
+        rust-version: ["1.61", latest]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}
     steps:
@@ -23,7 +23,7 @@ jobs:
     name: Build Complete
     strategy:
       matrix:
-        rust-version: ["1.56.1", "1.57", "1.58", "1.59", "1.60", "1.61", "1.62", "1.63", latest]
+        rust-version: ["1.61", latest]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     name: Build Python
     strategy:
       matrix:
-        rust-version: ["1.56.1", "1.57", "1.58", "1.59", "1.60", "1.61", "1.62", "1.63"]
+        rust-version: ["1.61", latest]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     container: rust:${{ matrix.rust-version }}-bullseye
     steps:
       - uses: actions/checkout@v1
-      - run: apt update && apt-get install python3.9 python3-pip
+      - run: apt update && apt-get install -y -q python3.9 python3-pip
       - run: cargo build --features python-extension
       - run: cargo run version
       - run: python3 -m pip3 install --upgrade .

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        rust-version: ["1.56.1", "1.57", "1.58", "1.59", "1.60", "1.61", "1.62", "1.63", latest]
+        rust-version: ["1.61", latest]
     runs-on: ubuntu-latest
     container: rust:${{ matrix.rust-version }}
     steps:


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Fixes the CI versions, since ubuntu-latest is now 22.04 and our image crate minimal rust version is now 1.61. |
| Animated GIF | -- |

Relevant:
- `error: package `image v0.24.5` cannot be built because it requires rustc 1.61.0 or newer, while the currently active rustc version is 1.56.1`
-  https://github.com/actions/setup-python/issues/370#issuecomment-1089903519
-  https://stackoverflow.com/a/74691151